### PR TITLE
FirestoreServiceのcreatedAt処理を改善

### DIFF
--- a/__tests__/services/firestoreService.test.ts
+++ b/__tests__/services/firestoreService.test.ts
@@ -87,6 +87,7 @@ describe('FirestoreService', () => {
       it('ユーザープロファイルを取得できる', async () => {
         // Given: モックの設定
         const mockDocSnap = {
+          id: 'user123',
           exists: () => true,
           data: () => ({
             name: '田中太郎',
@@ -247,7 +248,10 @@ describe('FirestoreService', () => {
         const mockDocSnap = {
           exists: () => true,
           id: 'vital123',
-          data: () => mockVitalData,
+          data: () => ({
+            ...mockVitalData,
+            createdAt: { toDate: () => new Date('2024-01-01') }
+          }),
         };
         (firestore.getDoc as jest.Mock).mockResolvedValue(mockDocSnap);
         (firestore.doc as jest.Mock).mockReturnValue('mock-doc-ref');
@@ -256,7 +260,11 @@ describe('FirestoreService', () => {
         const result = await getVitalData('vital123');
 
         // Then: 正しく取得される
-        expect(result).toEqual({ id: 'vital123', ...mockVitalData });
+        expect(result).toEqual({ 
+          id: 'vital123', 
+          ...mockVitalData,
+          createdAt: new Date('2024-01-01')
+        });
         expect(firestore.doc).toHaveBeenCalledWith({}, 'vitalData', 'vital123');
         expect(firestore.getDoc).toHaveBeenCalledWith('mock-doc-ref');
       });
@@ -283,11 +291,19 @@ describe('FirestoreService', () => {
         const mockDocs = [
           {
             id: 'vital1',
-            data: () => ({ ...mockVitalData, date: '2024-01-01' }),
+            data: () => ({ 
+              ...mockVitalData, 
+              date: '2024-01-01',
+              createdAt: { toDate: () => new Date('2024-01-01') }
+            }),
           },
           {
             id: 'vital2', 
-            data: () => ({ ...mockVitalData, date: '2024-01-02' }),
+            data: () => ({ 
+              ...mockVitalData, 
+              date: '2024-01-02',
+              createdAt: { toDate: () => new Date('2024-01-02') }
+            }),
           },
         ];
         const mockQuerySnapshot = {
@@ -311,6 +327,7 @@ describe('FirestoreService', () => {
           id: 'vital1',
           ...mockVitalData,
           date: '2024-01-01',
+          createdAt: new Date('2024-01-01')
         });
         expect(firestore.query).toHaveBeenCalled();
         expect(firestore.where).toHaveBeenCalledWith('userId', '==', 'user123');

--- a/src/services/firestoreService.ts
+++ b/src/services/firestoreService.ts
@@ -64,8 +64,8 @@ export const getUserProfile = async (userId: string): Promise<UserProfile | null
         id: userDoc.id,
         name: data.name,
         age: data.age,
-        createdAt: data.createdAt?.toDate() || new Date(data.createdAt),
-        updatedAt: data.updatedAt?.toDate() || new Date(data.updatedAt),
+        createdAt: data.createdAt?.toDate ? data.createdAt.toDate() : new Date(data.createdAt),
+        updatedAt: data.updatedAt?.toDate ? data.updatedAt.toDate() : new Date(data.updatedAt),
       };
     }
     
@@ -155,7 +155,7 @@ export const getVitalData = async (vitalId: string): Promise<VitalDataDocument |
         steps: data.steps,
         date: data.date,
         timestamp: data.timestamp,
-        createdAt: data.createdAt?.toDate() || new Date(data.createdAt),
+        createdAt: data.createdAt?.toDate ? data.createdAt.toDate() : new Date(data.createdAt),
       };
     }
     
@@ -203,7 +203,7 @@ export const getUserVitalHistory = async (
         steps: data.steps,
         date: data.date,
         timestamp: data.timestamp,
-        createdAt: data.createdAt?.toDate() || new Date(data.createdAt),
+        createdAt: data.createdAt?.toDate ? data.createdAt.toDate() : new Date(data.createdAt),
       };
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- FirestoreのserverTimestamp()との互換性を向上させるため、createdAtフィールドの処理を改善
- テストの安定性を向上

## 変更内容
- FirestoreServiceで`toDate`メソッドの存在チェックを追加
- テストモックに適切な`createdAt`フィールドを設定
- 105個のテスト全てが成功することを確認

## Test plan
- [x] 全テストスイート実行（11/11スイート、105/105テスト成功）
- [x] TypeScript型チェック成功
- [x] ESLint検証完了

🤖 Generated with [Claude Code](https://claude.ai/code)