### PR TITLE
fix: Firestore接続エラーの修正と匿名認証の実装

### DIFF
--- a/__tests__/integration/firestorePermissions.test.ts
+++ b/__tests__/integration/firestorePermissions.test.ts
@@ -1,0 +1,259 @@
+import { auth, db } from '../../src/config/firebase';
+import { 
+  signInAnonymously,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signOut,
+  User
+} from 'firebase/auth';
+import { 
+  doc, 
+  getDoc, 
+  setDoc, 
+  collection,
+  query,
+  where,
+  getDocs
+} from 'firebase/firestore';
+import { firestoreService } from '../../src/services/firestoreService';
+
+// Firebaseエミュレータを使用する場合のセットアップ
+const EMULATOR_HOST = process.env.FIREBASE_EMULATOR_HOST || 'localhost';
+const AUTH_EMULATOR_PORT = process.env.FIREBASE_AUTH_EMULATOR_PORT || '9099';
+const FIRESTORE_EMULATOR_PORT = process.env.FIRESTORE_EMULATOR_PORT || '8080';
+
+describe('Firestore Permissions Integration Tests', () => {
+  let testUser: User | null = null;
+  const testEmail = `test${Date.now()}@example.com`;
+  const testPassword = 'TestPassword123!';
+
+  beforeAll(async () => {
+    // エミュレータの使用（CI環境でのみ）
+    if (process.env.CI) {
+      const { connectAuthEmulator } = await import('firebase/auth');
+      const { connectFirestoreEmulator } = await import('firebase/firestore');
+      
+      try {
+        connectAuthEmulator(auth, `http://${EMULATOR_HOST}:${AUTH_EMULATOR_PORT}`);
+        connectFirestoreEmulator(db, EMULATOR_HOST, parseInt(FIRESTORE_EMULATOR_PORT));
+      } catch (error) {
+        // Already connected
+      }
+    }
+  });
+
+  afterEach(async () => {
+    // サインアウト
+    if (auth.currentUser) {
+      await signOut(auth);
+    }
+    testUser = null;
+  });
+
+  describe('認証ユーザーのFirestoreアクセス権限', () => {
+    beforeEach(async () => {
+      // テストユーザーを作成
+      try {
+        const userCredential = await createUserWithEmailAndPassword(auth, testEmail, testPassword);
+        testUser = userCredential.user;
+      } catch (error: any) {
+        if (error.code === 'auth/email-already-in-use') {
+          // 既存のユーザーでサインイン
+          const userCredential = await signInWithEmailAndPassword(auth, testEmail, testPassword);
+          testUser = userCredential.user;
+        } else {
+          throw error;
+        }
+      }
+    });
+
+    it('認証ユーザーは自分のプロファイルにアクセスできる', async () => {
+      expect(testUser).toBeTruthy();
+      if (!testUser) return;
+
+      // プロファイルを作成
+      const profileData = {
+        userId: testUser.uid,
+        email: testUser.email,
+        fullName: 'Test User',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      // Firestoreに保存
+      await setDoc(doc(db, 'userProfiles', testUser.uid), profileData);
+
+      // 読み取りテスト
+      const profile = await firestoreService.getUserProfile(testUser.uid);
+      expect(profile).toBeTruthy();
+      expect(profile?.email).toBe(testUser.email);
+    });
+
+    it('認証ユーザーは自分のリスクアセスメントデータにアクセスできる', async () => {
+      expect(testUser).toBeTruthy();
+      if (!testUser) return;
+
+      // リスクアセスメントデータを保存
+      const riskData = {
+        userId: testUser.uid,
+        date: new Date().toISOString(),
+        overallRiskScore: 50,
+        factors: {
+          activity: { score: 60, level: 'medium' },
+          mood: { score: 40, level: 'low' },
+        },
+        createdAt: new Date(),
+      };
+
+      await setDoc(doc(collection(db, 'riskAssessments')), riskData);
+
+      // 読み取りテスト
+      const assessments = await firestoreService.getRiskAssessments(testUser.uid);
+      expect(assessments).toBeTruthy();
+      expect(assessments.length).toBeGreaterThan(0);
+    });
+
+    it('認証ユーザーは他のユーザーのデータにアクセスできない', async () => {
+      expect(testUser).toBeTruthy();
+      if (!testUser) return;
+
+      const otherUserId = 'other-user-id';
+
+      // 他のユーザーのプロファイルへのアクセスを試みる
+      await expect(
+        firestoreService.getUserProfile(otherUserId)
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('匿名認証ユーザーのFirestoreアクセス権限', () => {
+    beforeEach(async () => {
+      // 匿名認証
+      const result = await signInAnonymously(auth);
+      testUser = result.user;
+    });
+
+    it('匿名ユーザーは限定的なデータにアクセスできる', async () => {
+      expect(testUser).toBeTruthy();
+      if (!testUser) return;
+
+      // 匿名ユーザー用の仮データを作成
+      const guestProfile = {
+        userId: testUser.uid,
+        isAnonymous: true,
+        createdAt: new Date(),
+      };
+
+      // プロファイルを保存（これは成功すべき）
+      await setDoc(doc(db, 'userProfiles', testUser.uid), guestProfile);
+
+      // 読み取りテスト
+      const profile = await getDoc(doc(db, 'userProfiles', testUser.uid));
+      expect(profile.exists()).toBe(true);
+    });
+
+    it('匿名ユーザーは自分のムードデータを保存できる', async () => {
+      expect(testUser).toBeTruthy();
+      if (!testUser) return;
+
+      const moodData = {
+        userId: testUser.uid,
+        mood: 'happy',
+        timestamp: new Date().toISOString(),
+        notes: 'テスト',
+        isAnonymous: true,
+      };
+
+      // ムードデータの保存をテスト
+      await firestoreService.saveMoodData(
+        testUser.uid,
+        moodData.mood,
+        moodData.notes
+      );
+
+      // 読み取りテスト
+      const savedMood = await firestoreService.getMoodData(testUser.uid);
+      expect(savedMood).toBeTruthy();
+      expect(savedMood.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('未認証ユーザーのアクセス制限', () => {
+    beforeEach(async () => {
+      // サインアウトして未認証状態にする
+      await signOut(auth);
+    });
+
+    it('未認証ユーザーはプロファイルデータにアクセスできない', async () => {
+      // 未認証状態でのアクセスを試みる
+      await expect(
+        firestoreService.getUserProfile('any-user-id')
+      ).rejects.toThrow();
+    });
+
+    it('未認証ユーザーはリスクアセスメントデータにアクセスできない', async () => {
+      await expect(
+        firestoreService.getRiskAssessments('any-user-id')
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('Firestoreセキュリティルールの検証', () => {
+    it('userProfilesコレクションは正しいアクセス制御を持つ', async () => {
+      // 認証ユーザーでテスト
+      const userCredential = await signInWithEmailAndPassword(auth, testEmail, testPassword);
+      const user = userCredential.user;
+
+      // 自分のドキュメントへの書き込み（成功すべき）
+      const myProfile = {
+        userId: user.uid,
+        email: user.email,
+        fullName: 'My Profile',
+        updatedAt: new Date(),
+      };
+
+      await expect(
+        setDoc(doc(db, 'userProfiles', user.uid), myProfile)
+      ).resolves.not.toThrow();
+
+      // 他人のドキュメントへの書き込み（失敗すべき）
+      const otherProfile = {
+        userId: 'other-user',
+        email: 'other@example.com',
+        fullName: 'Other Profile',
+        updatedAt: new Date(),
+      };
+
+      await expect(
+        setDoc(doc(db, 'userProfiles', 'other-user'), otherProfile)
+      ).rejects.toThrow();
+    });
+
+    it('stepDataコレクションはuserIdフィールドで制御される', async () => {
+      const userCredential = await signInWithEmailAndPassword(auth, testEmail, testPassword);
+      const user = userCredential.user;
+
+      // 自分のステップデータ（成功すべき）
+      const myStepData = {
+        userId: user.uid,
+        date: new Date().toISOString(),
+        steps: 5000,
+        createdAt: new Date(),
+      };
+
+      const docRef = doc(collection(db, 'stepData'));
+      await expect(
+        setDoc(docRef, myStepData)
+      ).resolves.not.toThrow();
+
+      // クエリで自分のデータを取得（成功すべき）
+      const q = query(
+        collection(db, 'stepData'),
+        where('userId', '==', user.uid)
+      );
+      
+      const querySnapshot = await getDocs(q);
+      expect(querySnapshot.size).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/screens/ElderlyHomeScreen.tsx
+++ b/src/screens/ElderlyHomeScreen.tsx
@@ -32,6 +32,7 @@ import { elderlyTheme } from '../styles/elderly-theme';
 // サービス
 import { firestoreService } from '../services/firestoreService';
 import { riskCalculationService } from '../services/riskCalculationService';
+import { getCurrentUser } from '../services/authService';
 
 // タイプ
 import { StackNavigationProp } from '@react-navigation/stack';
@@ -67,8 +68,12 @@ export const ElderlyHomeScreen: React.FC<Props> = ({ navigation }) => {
     try {
       setData(prev => ({ ...prev, loading: true, error: null }));
 
-      // ユーザーIDを取得（仮のユーザーIDを使用）
-      const userId = 'user1'; // TODO: 実際のユーザーIDを取得する
+      // 現在のユーザーを取得
+      const currentUser = await getCurrentUser();
+      if (!currentUser) {
+        throw new Error('ログインが必要です');
+      }
+      const userId = currentUser.id;
       
       // 並行してデータを取得（エラーハンドリングあり）
       const results = await Promise.allSettled([
@@ -81,7 +86,7 @@ export const ElderlyHomeScreen: React.FC<Props> = ({ navigation }) => {
       // すべて失敗した場合はエラー状態に
       const allFailed = results.every(result => result.status === 'rejected');
       if (allFailed) {
-        throw new Error('すべてのデータ取得に失敗しました');
+        throw new Error('すべてのデータ取得に失敗しました。データベースの権限設定を確認してください。');
       }
 
       // 成功した結果を取得

--- a/src/screens/ResponsiveElderlyHomeScreen.tsx
+++ b/src/screens/ResponsiveElderlyHomeScreen.tsx
@@ -45,6 +45,7 @@ import { Colors } from '../types';
 // サービス
 import { firestoreService } from '../services/firestoreService';
 import { riskCalculationService } from '../services/riskCalculationService';
+import { getCurrentUser } from '../services/authService';
 
 // タイプ
 import { StackNavigationProp } from '@react-navigation/stack';
@@ -82,8 +83,12 @@ export const ResponsiveElderlyHomeScreen: React.FC<Props> = ({ navigation }) => 
     try {
       setData(prev => ({ ...prev, loading: true, error: null }));
 
-      // ユーザーIDを取得（仮のユーザーIDを使用）
-      const userId = 'user1'; // TODO: 実際のユーザーIDを取得する
+      // 現在のユーザーを取得
+      const currentUser = await getCurrentUser();
+      if (!currentUser) {
+        throw new Error('ログインが必要です');
+      }
+      const userId = currentUser.id;
       
       // 並行してデータを取得（エラーハンドリングあり）
       const results = await Promise.allSettled([
@@ -96,7 +101,7 @@ export const ResponsiveElderlyHomeScreen: React.FC<Props> = ({ navigation }) => 
       // すべて失敗した場合はエラー状態に
       const allFailed = results.every(result => result.status === 'rejected');
       if (allFailed) {
-        throw new Error('すべてのデータ取得に失敗しました');
+        throw new Error('すべてのデータ取得に失敗しました。データベースの権限設定を確認してください。');
       }
 
       // 成功した結果を取得

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ export interface User {
   emergencyContact?: string;
   lineNotifyToken?: string;
   emailVerified?: boolean;
+  isAnonymous?: boolean;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## 概要
スクリーンショットで報告されたFirestore接続エラー「すべてのデータ取得に失敗しました。データベースの権限設定を確認してください。」を修正し、ユーザー体験を改善するための匿名認証機能を実装しました。

## 主な変更内容

### 🔧 Firestore接続エラーの修正
- ホーム画面でハードコードされた`'user1'`を実際の認証ユーザーIDに変更
- `ResponsiveElderlyHomeScreen.tsx`と`ElderlyHomeScreen.tsx`で`getCurrentUser()`を使用するように修正
- エラーメッセージを明確化

### 🔐 匿名認証機能の実装
- `signInAsGuest()`: 匿名ユーザーでのサインイン
- `isAnonymousUser()`: 匿名ユーザーかどうかの判定
- `convertAnonymousToAccount()`: 匿名アカウントから正式アカウントへの変換
- User型に`isAnonymous`フィールドを追加

### 📱 認証フローの最適化
既存の問題「ログイン済みなのに毎回オンボーディング画面から始まる」を解決：

**改善前**:
- 毎回オンボーディング画面から開始
- ログイン状態が保持されない

**改善後**:
- **既にログイン済み（通常/匿名）** → ダッシュボードから開始
- **初回起動** → オンボーディング → 自動匿名認証 → ダッシュボード  
- **2回目以降** → 自動匿名認証 → ダッシュボード

### 🧪 テスト追加
- Firestore権限テストを`__tests__/integration/firestorePermissions.test.ts`に追加
- 認証済み、匿名、未認証ユーザーのアクセスパターンをテスト

## 技術的詳細

### App.tsx の主な変更
```typescript
// 認証状態の監視と自動匿名認証
const unsubscribe = subscribeToAuthState(async (currentUser) => {
  if (currentUser) {
    // 認証済みユーザー → ダッシュボード
    setAppState('authenticated');
  } else if (\!isInitialized) {
    if (onboardingComplete === 'true') {
      // オンボーディング済み → 自動匿名認証
      await signInAsGuest();
      setAppState('authenticated');
    } else {
      // 初回起動 → オンボーディング
      setAppState('onboarding');
    }
  }
});
```

### ホーム画面の修正
```typescript
// 実際のユーザーIDを取得
const currentUser = await getCurrentUser();
if (\!currentUser) {
  throw new Error('ログインが必要です');
}
const userId = currentUser.id;
```

## テスト方法
1. アプリを初回起動 → オンボーディング → 自動的にダッシュボードへ
2. アプリを再起動 → 直接ダッシュボードから開始
3. ダッシュボードで接続エラーが表示されないことを確認

## 期待される効果
- ✅ Firestore接続エラーの解消
- ✅ スムーズな認証フロー（毎回ログインする必要なし）
- ✅ ゲストユーザーでもアプリの全機能を体験可能
- ✅ 後からアカウント登録への変換が可能

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 匿名ユーザーとしてのサインインや、匿名アカウントから通常アカウントへの変換機能を追加しました。
  - 匿名ユーザーや認証ユーザーの状態に応じて、アプリの初期化やオンボーディング後の自動サインインが行われるようになりました。
- **バグ修正**
  - ユーザーIDの取得がハードコーディングから動的取得に変更され、未ログイン時のエラーハンドリングが強化されました。
  - データ取得失敗時のエラーメッセージが、データベース権限設定の確認を促す内容に改善されました。
- **テスト**
  - Firestoreのアクセス権限やセキュリティルールを検証する統合テストが追加されました。
- **型定義**
  - ユーザー型に匿名ユーザー判定用のプロパティ（isAnonymous）が追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->